### PR TITLE
Minor refactor that also changes action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: "-3 --color"
 
   charts:
-    description: "List of charts to run tests for"
+    description: "Charts to run tests for, separated by spaces"
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+    - run: |
+        installScript=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+        curl "$installScript" 2>/dev/null | bash >/dev/null
       shell: bash
 
-    - run: helm plugin install https://github.com/quintush/helm-unittest
+    - run: |
+        helm plugin install https://github.com/quintush/helm-unittest >/dev/null 2>/dev/null
       shell: bash
 
     - run: |
@@ -29,7 +32,7 @@ runs:
 
     - run: |
         for chart in $(cat charts-to-test); do
-          helm dependency update "$chart"
+          helm dependency update "$chart" >/dev/null
         done
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,10 @@ name: "Helm Unit Tests"
 description: "Run Helm chart unit tests with quintush/helm-unittest"
 
 inputs:
-  helm3:
-    description: "Parse Helm charts as Helm3 charts"
+  flags:
+    description: "Flags to pass to helm unittest"
     required: false
-    default: true
+    default: "-3 --color"
 
   charts:
     description: "List of charts to run tests for"
@@ -33,4 +33,4 @@ runs:
           helm dependency update "$chart"
         done
 
-        helm unittest ${{ inputs.helm3 && '-3' || '' }} $charts
+        helm unittest ${{ inputs.flags }} $charts

--- a/action.yml
+++ b/action.yml
@@ -21,16 +21,17 @@ runs:
     - run: helm plugin install https://github.com/quintush/helm-unittest
       shell: bash
 
-    - shell: bash
-      run: |
-        charts="${{ inputs.charts }}"
+    - run: |
+        tr ' ' '\n' <<< "${{ inputs.charts }}" | grep -v '^$' > charts-to-test
+        find . -type f -name 'Chart.yaml' -exec dirname {} \; > all-charts
+        [ -z "${{ inputs.charts }}" ] && mv all-charts charts-to-test || true
+      shell: bash
 
-        if [ -z "$charts" ]; then
-          charts="$(find . -type f -name 'Chart.yaml' -exec dirname {} \;)"
-        fi
-
-        for chart in $charts; do
+    - run: |
+        for chart in $(cat charts-to-test); do
           helm dependency update "$chart"
         done
+      shell: bash
 
-        helm unittest ${{ inputs.flags }} $charts
+    - run: helm unittest ${{ inputs.flags }} $(cat charts-to-test)
+      shell: bash


### PR DESCRIPTION
Take command flags as input instead of whether it's a Helm v3 chart or not. This
way the user can specify whatever flags they wish to use with the `helm
unittest` command.

On top of that, refactor the action a little bit for legibility and
maintainability. Well, it looks cuter now, so there's that.
