### PR TITLE
Fix action when charts input is empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
 
     - run: |
-        tr ' ' '\n' <<< "${{ inputs.charts }}" | grep -v '^$' > charts-to-test
+        tr ' ' '\n' <<< "${{ inputs.charts }}" | grep -v '^$' > charts-to-test || true
         find . -type f -name 'Chart.yaml' -exec dirname {} \; > all-charts
         [ -z "${{ inputs.charts }}" ] && mv all-charts charts-to-test || true
       shell: bash


### PR DESCRIPTION
Account for grep's non-zero exit code for when there are no matches for grep to
output. Since by default the shell in GitHub Actions will run with the arguments
'set -eo pipefail', this empty output broke the action.
