### PR TITLE
Allow to set the version of the unittest plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,28 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           install-mode: if-not-present
 
+  test-action-unittest-version:
+    name: Unittest Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository files
+        uses: actions/checkout@v3
+      - name: Run composite action
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          unittest-version: v0.3.4
+          
+      - name: Check that helm-unittest is installed
+        run: helm plugin list | sed 1d | awk '{print $1}' | grep -q '^unittest$'
+
+      - name: Check that helm-unittest version is v0.3.4
+        run: helm plugin list | awk '/^unittest\s/ { found = 1; print $2 } END { exit !found }' | grep -q '^0.3.4$'
+      
+
+
   test-action-simple-install:
     name: Simple Install
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           unittest-version: v0.3.4
-          
+
       - name: Check that helm-unittest is installed
         run: helm plugin list | sed 1d | awk '{print $1}' | grep -q '^unittest$'
 
       - name: Check that helm-unittest version is v0.3.4
         run: helm plugin list | awk '/^unittest\s/ { found = 1; print $2 } END { exit !found }' | grep -q '^0.3.4$'
-      
-
 
   test-action-simple-install:
     name: Simple Install

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ repository.
 
 ## Options
 
-| Input          | Description                                                                                   | Required | Default   |
-|:---------------|:----------------------------------------------------------------------------------------------|:---------|:----------|
-| `flags`        | Which flags to pass to helm-unittest when running unit tests.                                 | No       | `--color` |
-| `charts`       | Paths to the charts to be tested, separated by spaces. If empty, all charts found are tested. | No       | `""`      |
-| `install-mode` | One of `"force"`, `"if-not-present"`, or `""`. More information below.                        | No       | `""`      |
-| `helm-version` | Which version of Helm to install. Passed to [azure/setup-helm][setup-helm].                   | Yes      | `latest`  |
-| `github-token` | GitHub token for the workflow. Passed to [azure/setup-helm][setup-helm]. Not always needed!   | No       | `""`      |
+| Input              | Description                                                                                   | Required | Default   |
+|:-------------------|:----------------------------------------------------------------------------------------------|:---------|:----------|
+| `flags`            | Which flags to pass to helm-unittest when running unit tests.                                 | No       | `--color` |
+| `charts`           | Paths to the charts to be tested, separated by spaces. If empty, all charts found are tested. | No       | `""`      |
+| `install-mode`     | One of `"force"`, `"if-not-present"`, or `""`. More information below.                        | No       | `""`      |
+| `unittest-version` | Which version of the helm-unittest plugin to install. Defaults to latest.                     | No       | `""`      |
+| `helm-version`     | Which version of Helm to install. Passed to [azure/setup-helm][setup-helm].                   | Yes      | `latest`  |
+| `github-token`     | GitHub token for the workflow. Passed to [azure/setup-helm][setup-helm]. Not always needed!   | No       | `""`      |
 
 The `github-token` input is necessary only when installing the latest version
 of Helm, to overcome GitHub API rate limits. If not given, refer to the

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,11 @@ inputs:
     required: true
     default: "latest"
 
+  unittest-version:
+    description: "Which version of helm-unittest to install"
+    required: false
+    default: ""
+
   github-token:
     description: "GitHub token, necessary to overcome API rate limits"
     required: false
@@ -59,8 +64,14 @@ runs:
             exit 1
           fi
         fi
-
-        helm plugin install https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null
+        helm_ut_plugin_version="${{ inputs.unittest-version }}"
+        if [ -n "$helm_ut_plugin_version" ]; then
+          echo "Installing version $helm_ut_plugin_version of helm-unittest"
+          helm plugin install --version "$helm_ut_plugin_version" https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null
+        else
+          echo "Installing latest version of helm-unittest"
+          helm plugin install https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null
+        fi
       shell: bash
 
     - name: Assemble list of chart directories to test


### PR DESCRIPTION
accept input for `unittest-version`

if not set, it will use the default "latest" version.
if it is set, specify that version during the install of the plugin 