### PR TITLE
feat: Allow unittest-version be set to 'latest' or empty string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,24 @@ jobs:
       - name: Check that helm-unittest version is v0.3.4
         run: helm plugin list | awk '/^unittest\s/ { found = 1; print $2 } END { exit !found }' | grep -q '^0.3.4$'
 
+  test-action-unittest-latest:
+    name: Unittest Version set to latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository files
+        uses: actions/checkout@v3
+      - name: Run composite action
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          unittest-version: latest
+
+      - name: Check that helm-unittest is installed
+        run: helm plugin list | sed 1d | awk '{print $1}' | grep -q '^unittest$'
+
+
   test-action-simple-install:
     name: Simple Install
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The `github-token` input is necessary only when installing the latest version
 of Helm, to overcome GitHub API rate limits. If not given, refer to the
 [azure/setup-helm][setup-helm] README for more information.
 
+### Unittest Version
+
+`unittest-version` can be set to an empty string, or to `latest`. This allows a github variable to be used to "pin" a version, or to use latest since you cannot set a variable to an empty string.
+
 ### Installation mode
 
 The `install-mode` input controls how `helm-unittest` should be installed.

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
           fi
         fi
         helm_ut_plugin_version="${{ inputs.unittest-version }}"
-        if [ -n "$helm_ut_plugin_version" ]; then
+        if [ -n "$helm_ut_plugin_version" ] && [ "$helm_ut_plugin_version" != "latest" ]; then
           echo "Installing version $helm_ut_plugin_version of helm-unittest"
           helm plugin install --version "$helm_ut_plugin_version" https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null
         else

--- a/action.yml
+++ b/action.yml
@@ -65,11 +65,7 @@ runs:
           fi
         fi
         helm_ut_plugin_version="${{ inputs.unittest-version }}"
-        # if helm_ut_plugin_version is "latest" set it to empty string
-        if [ "$helm_ut_plugin_version" = "latest" ]; then
-          helm_ut_plugin_version=""
-        fi
-        if [ -n "$helm_ut_plugin_version" ]; then
+        if [ -n "$helm_ut_plugin_version" ] && [ "$helm_ut_plugin_version" != "latest" ]; then
           echo "Installing version $helm_ut_plugin_version of helm-unittest"
           helm plugin install --version "$helm_ut_plugin_version" https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null
         else

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ runs:
           fi
         fi
         helm_ut_plugin_version="${{ inputs.unittest-version }}"
+        # if helm_ut_plugin_version is "latest" set it to empty string
+        if [ "$helm_ut_plugin_version" = "latest" ]; then
+          helm_ut_plugin_version=""
+        fi
         if [ -n "$helm_ut_plugin_version" ]; then
           echo "Installing version $helm_ut_plugin_version of helm-unittest"
           helm plugin install --version "$helm_ut_plugin_version" https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null


### PR DESCRIPTION
Allow the `unittest-version` property to be either an empty string, or `latest`. 

This addresses #15 