### PR TITLE
chore: bump azure helm action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@v4.0.0
       with:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v4
       with:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.github-token }}


### PR DESCRIPTION
This bumps the Azure Helm action to v4 to avoid
the deprecation of Node v16 based actions.

Fixes #17