### PR TITLE
fix: upgrade and pin azure/setup-helm

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Helm
-      uses: azure/setup-helm@v4.0.0
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       with:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.github-token }}


### PR DESCRIPTION
## what
- fix: upgrade and pin azure/setup-helm

## why
- https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide

## references
- https://github.com/Azure/setup-helm/releases/tag/v4.3.1